### PR TITLE
refactor: make discovery fully async

### DIFF
--- a/zigate/core.py
+++ b/zigate/core.py
@@ -521,6 +521,7 @@ class ZiGate(object):
             d = self.get_device_from_addr(addr)
             if d:
                 d.update_info(response.cleaned_data())
+                self.discover_device(addr)
         elif response.msg == 0x8043:  # simple descriptor
             addr = response['addr']
             endpoint = response['endpoint']
@@ -1157,6 +1158,7 @@ class ZiGate(object):
         if 'mac_capability' not in device.info:
             LOGGER.debug('no mac_capability')
             self.node_descriptor_request(addr)
+            return
         if not device.endpoints:
             LOGGER.debug('no endpoints')
             self.active_endpoint_request(addr)


### PR DESCRIPTION
Some devices doesn't support many simultaneous requests (I receive some error status).
This appends every time when I pair my Profalux BSO. 

That's why I suggest this PR to discover device attributes one by one.