### PR TITLE
Fix network discovery

### DIFF
--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -281,6 +281,16 @@ class TestResponses(unittest.TestCase):
                                           ('addr', 'abcd')
                                           ])
                              )
+        msg_data = unhexlify(b'38c10701060000')
+        r = responses.R804E(msg_data, 255)
+        self.assertDictEqual(r.cleaned_data(),
+                             OrderedDict([('sequence', 56), ('status', 193), ('entries', 7),
+                                          ('count', 1), ('index', 6),
+                                          ('lqi', 255),
+                                          ('neighbours', []),
+                                          ('addr', '0000')
+                                          ])
+                             )
 
     def test_response_8120(self):
         msg_data = unhexlify(b'011234010006000000')

--- a/zigate/core.py
+++ b/zigate/core.py
@@ -57,7 +57,7 @@ AUTO_SAVE = 5 * 60  # 5 minutes
 BIND_REPORT = True  # automatically bind and report state for light
 SLEEP_INTERVAL = 0.1
 ACTIONS = {}
-WAIT_TIMEOUT = 10
+WAIT_TIMEOUT = 5
 
 # Device id
 ACTUATORS = [0x0009, 0x0010, 0x0051,

--- a/zigate/responses.py
+++ b/zigate/responses.py
@@ -718,12 +718,14 @@ class R804E(Response):
         additional = self.data.pop('additional')
         neighbours = []
         for i in range(self.data['count']):
+            if len(additional) < 3:
+                break
             neighbour, additional = self._decode('!HQQBBB',
                                                  ['addr', 'extended_panid', 'ieee', 'depth', 'lqi', 'bit_field'],
                                                  additional)
             neighbours.append(neighbour)
         self.data['neighbours'] = neighbours
-        if additional:
+        if len(additional) >= 2:
             self.data['addr'] = struct.unpack('!H', additional)[0]
         self._format(self.data)
 # Bit map of attributes Described below: uint8_t


### PR DESCRIPTION
This PR improves network discovery by switching to an iterative scan of known zigbee devices.

UI changes originally in this were moved to #161 (and merged into dev).
TODO:
- [ ] avoid concurrent invocations of `_neighbours_table()`
