### PR TITLE
Improve admin panel index

### DIFF
--- a/zigate/adminpanel/__init__.py
+++ b/zigate/adminpanel/__init__.py
@@ -48,7 +48,7 @@ def start_adminpanel(zigate_instance, port=ADMINPANEL_PORT, mount=None, prefix=N
 
         grouped_devices = {}
         processed = []
-        def add_device_to_group(group, addr):
+        def add_device_to_group(group, addr, endpoint=""):
             name = "Missing"
             last_seen = ""
             if addr == "0000":
@@ -59,14 +59,15 @@ def start_adminpanel(zigate_instance, port=ADMINPANEL_PORT, mount=None, prefix=N
                 last_seen = zdev.info["last_seen"]
             else:
                 name = "{} ({})".format(name, addr)
-            group.append({"addr": addr, "name": name, "last_seen": last_seen})
+            group.append({"addr": addr, "endpoint": endpoint, "name": name, "last_seen": last_seen})
 
         for group, group_devices in zigate_instance.groups.items():
             grouped_devices[group] = []
             for device in group_devices:
                 addr = device[0]
+                endpoint = device[1]
                 processed.append(addr)
-                add_device_to_group(grouped_devices[group], addr)
+                add_device_to_group(grouped_devices[group], addr, endpoint)
 		
         grouped_devices[""] = []
         for device in zigate_instance.devices:

--- a/zigate/adminpanel/views/index.tpl
+++ b/zigate/adminpanel/views/index.tpl
@@ -46,6 +46,7 @@
 		<thead>
 			<tr>
 				<th>Group</th>
+				<th>Endpoint</th>
 				<th>Device</th>
 				<th>Last Seen</th>
 			<tr>
@@ -56,6 +57,9 @@
 			<tr>
 				% if i == 0:
 				<td rowspan="{{len(group_devices)}}">{{group}}</td>
+				% end
+				% if group or i == 0:
+				<td rowspan="{{1 if group else len(group_devices)}}">{{device['endpoint']}}</td>
 				% end
 				<td><a href="{{get_url('device', addr=device['addr'])}}">{{device['name']}}</a></td>
 				<td>{{device['last_seen']}}</td>

--- a/zigate/adminpanel/views/index.tpl
+++ b/zigate/adminpanel/views/index.tpl
@@ -1,32 +1,87 @@
 % rebase('base.tpl')
-<ul>
-	<li>Lib version : {{libversion}}</li>
-	<li>Port : {{port}}</li>
-	<li>Connected : {{connected}}</li>
-	<li>Firmware version : {{version}}</li>
-	<li>Model : {{model}}</li>
-</ul>
+<div style="display: inline-block; vertical-align: top;">
+	<h3>ZiGate</h3>
+	<table class="pure-table pure-table-bordered">
+		<thead>
+			<tr>
+				<th>Attribute</th>
+				<th>Value</th>
+			<tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>Lib version</td>
+				<td>{{libversion}}</td>
+			</tr>
+			<tr>
+				<td>Port</td>
+				<td>{{port}}</td>
+			</tr>
+			<tr>
+				<td>Connected</td>
+				<td>{{connected}}</td>
+			</tr>
+			<tr>
+				<td>Firmware version</td>
+				<td>{{version}}</td>
+			</tr>
+			<tr>
+				<td>Model</td>
+				<td>{{model}}</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
 
-<h2>Devices :</h2>
-<table class="pure-table pure-table-bordered">
-	<thead>
-		<tr>
-			<th>Device</th>
-			<th>Last Seen</th>
-		<tr>
-	</thead>
-	<tbody>
-	  % for device in devices:
-	  	<tr>
-	    	<td><a href="{{get_url('device', addr=device.addr)}}">{{device}}</a></td>
-	    	<td>{{device.info.get('last_seen')}}</td>
-	    </tr>
-	  % end
-  	</tbody>
-</table>
+<div style="display: inline-block; vertical-align: top;">
+	<h3>Actions</h3>
+	<a class="pure-button" href="{{get_url('api_permit_join')}}">Permit Join</a>
+</div>
 
-<h2>Groups :</h2>
-{{groups}}
+<br>
 
-<h2>Actions :</h2>
-<a class="pure-button" href="{{get_url('api_permit_join')}}">Permit Join</a>
+<div style="display: inline-block; vertical-align: top;">
+	<h3>Devices</h3>
+	<table class="pure-table pure-table-bordered">
+		<thead>
+			<tr>
+				<th>Group</th>
+				<th>Device</th>
+				<th>Last Seen</th>
+			<tr>
+		</thead>
+		<tbody>
+		% for group, group_devices in grouped_devices.items():
+			% for i, device in enumerate(group_devices):
+			<tr>
+				% if i == 0:
+				<td rowspan="{{len(group_devices)}}">{{group}}</td>
+				% end
+				<td><a href="{{get_url('device', addr=device['addr'])}}">{{device['name']}}</a></td>
+				<td>{{device['last_seen']}}</td>
+			</tr>
+			%end
+		% end
+		</tbody>
+	</table>
+</div>
+
+<div style="display: inline-block; vertical-align: top;">
+	<h3>Groups</h3>
+	<table class="pure-table pure-table-bordered">
+		<thead>
+			<tr>
+				<th>Group</th>
+				<th>Devices</th>
+			<tr>
+		</thead>
+		<tbody>
+		% for group, group_devices in groups.items():
+			<tr>
+				<td>{{group}}</td>
+				<td>{{group_devices}}</td>
+			</tr>
+		% end
+		</tbody>
+	</table>
+</div>


### PR DESCRIPTION
This PR improves the presentation of the admin panel index view.

![image](https://user-images.githubusercontent.com/318490/71928583-1bd5ae00-3198-11ea-8e63-d51c8f815bf7.png)

The devices table has a new column group and devices in the same group are displayed along side.

TODO:

- [ ] remove _Groups_ table and `groups` view parameter.