### PR TITLE
add admin panel host customization

### DIFF
--- a/zigate/__main__.py
+++ b/zigate/__main__.py
@@ -24,6 +24,7 @@ parser.add_argument('--gpio', help='Enable PiZigate', default=False, action='sto
 parser.add_argument('--channel', help='Zigbee channel', default=None)
 parser.add_argument('--admin_panel', help='Enable Admin panel', default=True, action='store_true')
 parser.add_argument('--admin_panel_port', help='Admin panel url prefix', default=9998)
+parser.add_argument('--admin_panel_host', help='Admin panel url prefix', default="0.0.0.0")
 parser.add_argument('--admin_panel_mount', help='Admin panel url mount point', default=None)
 parser.add_argument('--admin_panel_prefix', help='Admin panel url prefix', default=None)
 args = parser.parse_args()
@@ -31,12 +32,12 @@ if args.debug:
     logging.root.setLevel(logging.DEBUG)
 z = connect(args.port, args.host, args.path, True, True, args.channel, args.gpio)
 if args.admin_panel:
-    logging.root.info('Starting Admin Panel on port %s', args.admin_panel_port)
+    logging.root.info('Starting Admin Panel on %s:%s', args.admin_panel_host, args.admin_panel_port)
     if args.admin_panel_mount:
         logging.root.info('Mount point is %s', args.admin_panel_mount)
     if args.admin_panel_prefix:
         logging.root.info('URL prefix is %s', args.admin_panel_prefix)
-    z.start_adminpanel(port=int(args.admin_panel_port), mount=args.admin_panel_mount, prefix=args.admin_panel_prefix,
+    z.start_adminpanel(port=int(args.admin_panel_port), host=args.admin_panel_host, mount=args.admin_panel_mount, prefix=args.admin_panel_prefix,
                        debug=args.debug)
 print('Press Ctrl+C to quit')
 try:

--- a/zigate/adminpanel/__init__.py
+++ b/zigate/adminpanel/__init__.py
@@ -11,14 +11,14 @@ import bottle
 from json import dumps
 from zigate import version as zigate_version
 from zigate.core import DeviceEncoder
-from zigate.const import ADMINPANEL_PORT
+from zigate.const import ADMINPANEL_PORT, ADMINPANEL_HOST
 import time
 
 
 bottle.TEMPLATE_PATH.insert(0, os.path.join(os.path.dirname(__file__), 'views/'))
 
 
-def start_adminpanel(zigate_instance, port=ADMINPANEL_PORT, mount=None, prefix=None,
+def start_adminpanel(zigate_instance, host=ADMINPANEL_HOST, port=ADMINPANEL_PORT, mount=None, prefix=None,
                      autostart=True, daemon=True, quiet=True, debug=False):
     '''
     mount: url prefix used to mount bottle application
@@ -180,7 +180,7 @@ def start_adminpanel(zigate_instance, port=ADMINPANEL_PORT, mount=None, prefix=N
         force = bottle.request.query.get('force', 'false') == 'true'
         return {'network_table': zigate_instance.build_neighbours_table(force)}
 
-    kwargs = {'host': '0.0.0.0', 'port': port,
+    kwargs = {'host': host, 'port': port,
               'quiet': quiet, 'debug': debug}
 
     if autostart:

--- a/zigate/const.py
+++ b/zigate/const.py
@@ -88,3 +88,5 @@ DATA_TYPE = {0x00: None,
 BASE_PATH = os.path.dirname(__file__)
 
 ADMINPANEL_PORT = 9998
+ADMINPANEL_HOST = "0.0.0.0"
+

--- a/zigate/core.py
+++ b/zigate/core.py
@@ -284,13 +284,14 @@ class ZiGate(object):
     def addr(self):
         return self._addr
 
-    def start_adminpanel(self, port=None, mount=None, prefix=None, debug=False):
+    def start_adminpanel(self, host=None, port=None, mount=None, prefix=None, debug=False):
         '''
         Start Admin panel in other thread
         '''
-        from .adminpanel import start_adminpanel, ADMINPANEL_PORT
+        from .adminpanel import start_adminpanel, ADMINPANEL_HOST, ADMINPANEL_PORT
         port = port or ADMINPANEL_PORT
-        self.adminpanel = start_adminpanel(self, port=port, mount=mount, prefix=prefix, quiet=not debug, debug=debug)
+        host = host or ADMINPANEL_HOST
+        self.adminpanel = start_adminpanel(self, host=host, port=port, mount=mount, prefix=prefix, quiet=not debug, debug=debug)
         return self.adminpanel
 
     def _event_loop(self):


### PR DESCRIPTION
add --admin_panel_host parameter in order to set other than 0.0.0.0 as tcp listening adresses wich still default.